### PR TITLE
StrictConcurrencyを有効にする、Sendableを付ける

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,9 +26,7 @@ let package = Package(
                 .product(name: "SwiftTypeReader", package: "SwiftTypeReader"),
                 .product(name: "TypeScriptAST", package: "TypeScriptAST")
             ],
-            swiftSettings: [
-                .enableUpcomingFeature("BareSlashRegexLiterals"),
-            ]
+            swiftSettings: swiftSettings()
         ),
         .testTarget(
             name: "CodableToTypeScriptTests",
@@ -39,3 +37,10 @@ let package = Package(
         ),
     ]
 )
+
+func swiftSettings() -> [SwiftSetting] {
+    return [
+        .enableUpcomingFeature("BareSlashRegexLiterals"),
+        .enableExperimentalFeature("StrictConcurrency")
+    ]
+}

--- a/Sources/CodableToTypeScript/Extensions/TSASTEx.swift
+++ b/Sources/CodableToTypeScript/Extensions/TSASTEx.swift
@@ -49,6 +49,6 @@ extension TSIdentType {
 }
 
 extension TSIdentExpr {
-    static let json = TSIdentExpr("json")
-    static let entity = TSIdentExpr("entity")
+    static var json: TSIdentExpr { TSIdentExpr("json") }
+    static var entity: TSIdentExpr { TSIdentExpr("entity") }
 }

--- a/Sources/CodableToTypeScript/Value/CodecPresence.swift
+++ b/Sources/CodableToTypeScript/Value/CodecPresence.swift
@@ -1,4 +1,4 @@
-public enum CodecPresence: Int, Comparable {
+public enum CodecPresence: Int, Sendable & Hashable & Comparable {
     case identity       = 0
     case conditional    = 1
     case required       = 2

--- a/Sources/CodableToTypeScript/Value/GenerationTarget.swift
+++ b/Sources/CodableToTypeScript/Value/GenerationTarget.swift
@@ -1,4 +1,4 @@
-public enum GenerationTarget {
+public enum GenerationTarget: Sendable & Hashable {
     case entity
     case json
 }

--- a/Sources/CodableToTypeScript/Value/NamePath.swift
+++ b/Sources/CodableToTypeScript/Value/NamePath.swift
@@ -1,4 +1,4 @@
-struct NamePath {
+struct NamePath: Sendable & Hashable {
     var items: [String]
 
     init(_ items: [String]) {

--- a/Sources/CodableToTypeScript/Value/TSKeyword.swift
+++ b/Sources/CodableToTypeScript/Value/TSKeyword.swift
@@ -1,4 +1,4 @@
-enum TSKeyword: String {
+enum TSKeyword: String, Sendable & Hashable {
     case `break`
     case `case`
     case `catch`

--- a/Sources/CodableToTypeScript/Value/TypeMap.swift
+++ b/Sources/CodableToTypeScript/Value/TypeMap.swift
@@ -1,7 +1,7 @@
 import SwiftTypeReader
 
-public struct TypeMap {
-    public struct Entry {
+public struct TypeMap: Sendable {
+    public struct Entry: Sendable {
         public static func identity(name: String) -> Entry {
             return Entry(
                 entityType: name,
@@ -43,8 +43,8 @@ public struct TypeMap {
         }
     }
 
-    public typealias MapFunction = (any SType) -> Entry?
-    
+    public typealias MapFunction = @Sendable (any SType) -> Entry?
+
     public static let `default` = TypeMap(
         table: TypeMap.defaultTable
     )
@@ -69,7 +69,7 @@ public struct TypeMap {
     ]
 
     public init(
-        table: [String : Entry]? = nil,
+        table: [String: Entry]? = nil,
         mapFunction: MapFunction? = nil
     ) {
         self.table = table ?? Self.defaultTable


### PR DESCRIPTION
C2TSを利用するアプリケーションのビルド時に、
一部でSendable警告が出てしまうので対応する

TSASTはミュータブルなASTなのでSendableにならない。
Generator関係は抽象化が複雑でできるかわからないのでやらなかった。

これ以外で、C2TSで導入されるvalue semanticなものはSendableにした。

TypeMapのMapFunctionがSendableになったのは、
厳密には下位互換を破壊する。
しかし、利用する場面ではそこまでダイナミックな処理に接続しているとは考えにくくて、
多少複雑な判定をする程度で対応できると思う。