### PR TITLE
パスの先頭部分を置き換える機能の追加

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
+      "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
-        "version" : "1.1.3"
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
       }
     },
     {
@@ -14,17 +14,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {
       "identity" : "swifttypereader",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/omochi/SwiftTypeReader",
+      "location" : "https://github.com/omochi/SwiftTypeReader.git",
       "state" : {
-        "revision" : "0954567ba2d3de21c65f1887af7565db0d979da2",
-        "version" : "3.0.0"
+        "branch" : "swift-syntax-601",
+        "revision" : "531f466e99cc0a1c438319032c8115557131da5d"
       }
     },
     {
@@ -33,7 +33,7 @@
       "location" : "https://github.com/omochi/TypeScriptAST.git",
       "state" : {
         "branch" : "path-alias",
-        "revision" : "c495768c387046826636911aabe2b53cfbaac9c6"
+        "revision" : "29842e73dab5b1e1458f65ef3f57fe32b18b131a"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader.git",
       "state" : {
-        "branch" : "swift-syntax-601",
-        "revision" : "531f466e99cc0a1c438319032c8115557131da5d"
+        "revision" : "bda0cbe9cb561e70d87e0e5843c1e068d79867ba",
+        "version" : "3.2.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST.git",
       "state" : {
-        "branch" : "path-alias",
-        "revision" : "29842e73dab5b1e1458f65ef3f57fe32b18b131a"
+        "revision" : "2d4709364a1d80751179efa34bc3c9bb0709bd1b",
+        "version" : "2.1.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -30,10 +30,10 @@
     {
       "identity" : "typescriptast",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/omochi/TypeScriptAST",
+      "location" : "https://github.com/omochi/TypeScriptAST.git",
       "state" : {
-        "revision" : "4f6420d45d6dabc79b30954ea3aa524b7810a68b",
-        "version" : "2.0.1"
+        "branch" : "path-alias",
+        "revision" : "c495768c387046826636911aabe2b53cfbaac9c6"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/omochi/SwiftTypeReader.git", from: "3.0.0"),
 //        .package(path: "../SwiftTypeReader"),
-        .package(url: "https://github.com/omochi/TypeScriptAST.git", from: "2.0.1"),
+        .package(url: "https://github.com/omochi/TypeScriptAST.git", branch: "path-alias"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -12,9 +12,10 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/omochi/SwiftTypeReader.git", from: "3.0.0"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader.git", branch: "swift-syntax-601"),
 //        .package(path: "../SwiftTypeReader"),
         .package(url: "https://github.com/omochi/TypeScriptAST.git", branch: "path-alias"),
+//        .package(path: "../TypeScriptAST"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,20 @@
 
 import PackageDescription
 
+let isLocalDevelopment = false
+
+let dependencies: [Package.Dependency] = if isLocalDevelopment {
+    [
+        .package(path: "../SwiftTypeReader"),
+        .package(path: "../TypeScriptAST"),
+    ]
+} else {
+    [
+        .package(url: "https://github.com/omochi/SwiftTypeReader.git", from: "3.2.0"),
+        .package(url: "https://github.com/omochi/TypeScriptAST.git", from: "2.1.0"),
+    ]
+}
+
 let package = Package(
     name: "CodableToTypeScript",
     platforms: [.macOS(.v13)],
@@ -11,12 +25,7 @@ let package = Package(
             targets: ["CodableToTypeScript"]
         )
     ],
-    dependencies: [
-        .package(url: "https://github.com/omochi/SwiftTypeReader.git", branch: "swift-syntax-601"),
-//        .package(path: "../SwiftTypeReader"),
-        .package(url: "https://github.com/omochi/TypeScriptAST.git", branch: "path-alias"),
-//        .package(path: "../TypeScriptAST"),
-    ],
+    dependencies: dependencies,
     targets: [
         .target(
             name: "TestUtils"

--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -11,7 +11,8 @@ public final class PackageGenerator {
         symbols: SymbolTable,
         importFileExtension: ImportFileExtension,
         outputDirectory: URL,
-        typeScriptExtension: String = "ts"
+        typeScriptExtension: String = "ts",
+        pathAliases: PathAliasTable = .init()
     ) {
         self.context = context
         self.fileManager = fileManager
@@ -26,6 +27,7 @@ public final class PackageGenerator {
             isDirectory: true, relativeTo: outputDirectory.baseURL
         )
         self.typeScriptExtension = typeScriptExtension
+        self.pathAliases = pathAliases
     }
 
     public let context: SwiftTypeReader.Context
@@ -35,6 +37,7 @@ public final class PackageGenerator {
     public let importFileExtension: ImportFileExtension
     public let outputDirectory: URL
     public let typeScriptExtension: String
+    public let pathAliases: PathAliasTable
     @available(*, deprecated, renamed: "didConvertSource")
     public var didGenerateEntry: ((SourceFile, PackageEntry) throws -> Void)? {
         get { didConvertSource }
@@ -111,7 +114,8 @@ public final class PackageGenerator {
                     let imports = try tsSource.buildAutoImportDecls(
                         from: entry.file,
                         symbolTable: allSymbols,
-                        fileExtension: importFileExtension
+                        fileExtension: importFileExtension,
+                        pathAliasTable: pathAliases
                     )
                     tsSource.replaceImportDecls(imports)
                     for importedSymbolName in imports.flatMap(\.names) {

--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -12,7 +12,7 @@ public final class PackageGenerator {
         importFileExtension: ImportFileExtension,
         outputDirectory: URL,
         typeScriptExtension: String = "ts",
-        pathAliases: PathAliasTable = .init()
+        pathPrefixReplacements: PathPrefixReplacements = []
     ) {
         self.context = context
         self.fileManager = fileManager
@@ -27,7 +27,7 @@ public final class PackageGenerator {
             isDirectory: true, relativeTo: outputDirectory.baseURL
         )
         self.typeScriptExtension = typeScriptExtension
-        self.pathAliases = pathAliases
+        self.pathPrefixReplacements = pathPrefixReplacements
     }
 
     public let context: SwiftTypeReader.Context
@@ -37,7 +37,7 @@ public final class PackageGenerator {
     public let importFileExtension: ImportFileExtension
     public let outputDirectory: URL
     public let typeScriptExtension: String
-    public let pathAliases: PathAliasTable
+    public let pathPrefixReplacements: PathPrefixReplacements
     @available(*, deprecated, renamed: "didConvertSource")
     public var didGenerateEntry: ((SourceFile, PackageEntry) throws -> Void)? {
         get { didConvertSource }
@@ -115,7 +115,7 @@ public final class PackageGenerator {
                         from: entry.file,
                         symbolTable: allSymbols,
                         fileExtension: importFileExtension,
-                        pathAliasTable: pathAliases
+                        pathPrefixReplacements: pathPrefixReplacements
                     )
                     tsSource.replaceImportDecls(imports)
                     for importedSymbolName in imports.flatMap(\.names) {


### PR DESCRIPTION
- https://github.com/omochi/TypeScriptAST/pull/45

の機能を `PackageGenerator ` から利用できるインターフェースを提供する

テストコードを追加したかったが、
`assertGenerate` はフルスペックのリアルなコード生成を行なっていないため、
import文をひとまとめで `".."` に逃げていて、
これの生成部分をちゃんと触るのが難しかったので見送った。