### PR TITLE
struct と enum では常に decoder / encoder を生成する

### DIFF
--- a/Sources/CodableToTypeScript/Generator/CodeGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/CodeGenerator.swift
@@ -79,6 +79,23 @@ public final class CodeGenerator {
         }
     }
 
+    internal struct UsesIdentityDecodeRequest: Request {
+        var token: RequestToken
+        @AnyTypeStorage var type: any SType
+
+        func evaluate(on evaluator: RequestEvaluator) throws -> Bool {
+            do {
+                let converter = try token.generator.implConverter(for: type)
+                return try converter.usesIdentityDecode()
+            } catch {
+                switch error {
+                case is CycleRequestError: return false
+                default: throw error
+                }
+            }
+        }
+    }
+
     internal struct HasEncodeRequest: Request {
         var token: RequestToken
         @AnyTypeStorage var type: any SType
@@ -90,6 +107,23 @@ public final class CodeGenerator {
             } catch {
                 switch error {
                 case is CycleRequestError: return true
+                default: throw error
+                }
+            }
+        }
+    }
+
+    internal struct UsesIdentityEncodeRequest: Request {
+        var token: RequestToken
+        @AnyTypeStorage var type: any SType
+
+        func evaluate(on evaluator: RequestEvaluator) throws -> Bool {
+            do {
+                let converter = try token.generator.implConverter(for: type)
+                return try converter.usesIdentityEncode()
+            } catch {
+                switch error {
+                case is CycleRequestError: return false
                 default: throw error
                 }
             }

--- a/Sources/CodableToTypeScript/TypeConverter/ArrayConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/ArrayConverter.swift
@@ -29,6 +29,10 @@ public struct ArrayConverter: TypeConverter {
         return try element().hasDecode()
     }
 
+    public func usesIdentityDecode() throws -> Bool {
+        return try element().usesIdentityDecode()
+    }
+
     public func decodeName() throws -> String {
         return generator.helperLibrary().name(.arrayDecode)
     }
@@ -46,6 +50,10 @@ public struct ArrayConverter: TypeConverter {
 
     public func hasEncode() throws -> Bool {
         return try element().hasEncode()
+    }
+
+    public func usesIdentityEncode() throws -> Bool {
+        return try element().usesIdentityEncode()
     }
 
     public func encodeName() throws -> String {

--- a/Sources/CodableToTypeScript/TypeConverter/DefaultTypeConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/DefaultTypeConverter.swift
@@ -95,7 +95,7 @@ public struct DefaultTypeConverter {
     public func boundDecode() throws -> any TSExpr {
         let converter = try self.converter()
 
-        if try converter.usesIdentityDecode() {
+        if try converter.usesIdentityDecode() && !converter.hasJSONType() {
             return generator.helperLibrary().access(.identity)
         }
 
@@ -237,7 +237,7 @@ public struct DefaultTypeConverter {
     public func boundEncode() throws -> any TSExpr {
         let converter = try self.converter()
 
-        if try converter.usesIdentityEncode() {
+        if try converter.usesIdentityEncode() && !converter.hasJSONType() {
             return generator.helperLibrary().access(.identity)
         }
 

--- a/Sources/CodableToTypeScript/TypeConverter/DefaultTypeConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/DefaultTypeConverter.swift
@@ -87,10 +87,15 @@ public struct DefaultTypeConverter {
         return "\(entityName)_decode"
     }
 
+    public func usesIdentityDecode() throws -> Bool {
+        let converter = try self.converter()
+        return try !converter.hasDecode()
+    }
+
     public func boundDecode() throws -> any TSExpr {
         let converter = try self.converter()
 
-        guard try converter.hasDecode() else {
+        if try converter.usesIdentityDecode() {
             return generator.helperLibrary().access(.identity)
         }
 
@@ -124,10 +129,13 @@ public struct DefaultTypeConverter {
 
     public func callDecode(genericArgs: [any SType], json: any TSExpr) throws -> any TSExpr {
         let converter = try self.converter()
-        guard try converter.hasDecode() else {
+        if try converter.usesIdentityDecode() {
             var expr = json
             if try converter.hasJSONType() || !genericArgs.isEmpty {
-                expr = TSAsExpr(expr, try converter.type(for: .entity))
+                expr = TSAsExpr(
+                    TSAsExpr(expr, TSIdentType("unknown")),
+                    try converter.type(for: .entity)
+                )
             }
             return expr
         }
@@ -221,10 +229,15 @@ public struct DefaultTypeConverter {
         return "\(entityName)_encode"
     }
 
+    public func usesIdentityEncode() throws -> Bool {
+        let converter = try self.converter()
+        return try !converter.hasEncode()
+    }
+
     public func boundEncode() throws -> any TSExpr {
         let converter = try self.converter()
 
-        guard try converter.hasEncode() else {
+        if try converter.usesIdentityEncode() {
             return generator.helperLibrary().access(.identity)
         }
 
@@ -258,10 +271,13 @@ public struct DefaultTypeConverter {
 
     public func callEncode(genericArgs: [any SType], entity: any TSExpr) throws -> any TSExpr {
         let converter = try self.converter()
-        guard try converter.hasEncode() else {
+        if try converter.usesIdentityEncode() {
             var expr = entity
             if try converter.hasJSONType() || !genericArgs.isEmpty {
-                expr = TSAsExpr(expr, try converter.type(for: .json))
+                expr = TSAsExpr(
+                    TSAsExpr(expr, TSIdentType("unknown")),
+                    try converter.type(for: .json)
+                )
             }
             return expr
         }

--- a/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
@@ -60,12 +60,6 @@ public struct EnumConverter: TypeConverter {
     }
 
     public func typeDecl(for target: GenerationTarget) throws -> TSTypeDecl? {
-        switch target {
-        case .entity: break
-        case .json:
-            guard try hasJSONType() else { return nil }
-        }
-
         let genericParams: [TSTypeParameterNode] = try self.genericParams().map {
             .init(try $0.name(for: target))
         }
@@ -216,19 +210,37 @@ public struct EnumConverter: TypeConverter {
     }
 
     public func hasDecode() throws -> Bool {
+        return true
+    }
+
+    public func usesIdentityDecode() throws -> Bool {
         switch kind {
-        case .never: return false
-        case .void: return false
-        case .string: return false
-        case .int: return true
-        case .normal: return true
+        case .never: return true
+        case .void: return true
+        case .string: return true
+        case .int: return false
+        case .normal: return false
         }
     }
 
     public func decodeDecl() throws -> TSFunctionDecl? {
+        if try usesIdentityDecode() {
+            guard let decl = try decodeSignature() else { return nil }
+            let expr: any TSExpr = switch kind {
+            case .void:
+                TSAsExpr(TSIdentExpr.json, try type(for: .entity))
+            default:
+                TSIdentExpr.json
+            }
+            decl.body.elements.append(
+                TSReturnStmt(expr)
+            )
+            return decl
+        }
+
         switch kind {
         case .never, .void, .string:
-            return nil
+            throw MessageError("Unexpected enum decode kind: \(kind)")
         case .int:
             return try DecodeIntFuncGen(
                 converter: self,
@@ -244,38 +256,37 @@ public struct EnumConverter: TypeConverter {
     }
 
     public func hasEncode() throws -> Bool {
+        return true
+    }
+
+    public func usesIdentityEncode() throws -> Bool {
         switch kind {
-        case .never: return false
-        case .void: return false
-        case .string: return false
-        case .int: return true
-        case .normal: break
+        case .never: return true
+        case .void: return true
+        case .string: return true
+        case .int: return false
+        case .normal: return false
         }
-
-        let map = `enum`.contextSubstitutionMap()
-
-        var result = false
-
-        try withErrorCollector { collect in
-            for caseElement in decl.caseElements {
-                for (i, value) in caseElement.associatedValues.enumerated() {
-                    result = result || collect(at: "\(caseElement.name).\(value.interfaceName ?? "_\(i)")") {
-                        let value = try generator.converter(
-                            for: value.interfaceType.subst(map: map)
-                        )
-                        return try value.hasEncode()
-                    } ?? false
-                }
-            }
-        }
-
-        return result
     }
 
     public func encodeDecl() throws -> TSFunctionDecl? {
+        if try usesIdentityEncode() {
+            guard let decl = try encodeSignature() else { return nil }
+            let expr: any TSExpr = switch kind {
+            case .void:
+                TSAsExpr(TSIdentExpr.entity, try type(for: .json))
+            default:
+                TSIdentExpr.entity
+            }
+            decl.body.elements.append(
+                TSReturnStmt(expr)
+            )
+            return decl
+        }
+
         switch kind {
         case .never, .void, .string:
-            return nil
+            throw MessageError("Unexpected enum encode kind: \(kind)")
         case .int:
             return try EncodeIntFuncGen(
                 converter: self,

--- a/Sources/CodableToTypeScript/TypeConverter/GeneratorProxyConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/GeneratorProxyConverter.swift
@@ -37,6 +37,12 @@ struct GeneratorProxyConverter: TypeConverter {
         )
     }
 
+    func usesIdentityDecode() throws -> Bool {
+        return try generator.context.evaluator(
+            CodeGenerator.UsesIdentityDecodeRequest(token: generator.requestToken, type: swiftType)
+        )
+    }
+
     func decodeName() throws -> String {
         return try impl.decodeName()
     }
@@ -64,6 +70,12 @@ struct GeneratorProxyConverter: TypeConverter {
     func hasEncode() throws -> Bool {
         return try generator.context.evaluator(
             CodeGenerator.HasEncodeRequest(token: generator.requestToken, type: swiftType)
+        )
+    }
+
+    func usesIdentityEncode() throws -> Bool {
+        return try generator.context.evaluator(
+            CodeGenerator.UsesIdentityEncodeRequest(token: generator.requestToken, type: swiftType)
         )
     }
 

--- a/Sources/CodableToTypeScript/TypeConverter/OptionalConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/OptionalConverter.swift
@@ -45,6 +45,10 @@ public struct OptionalConverter: TypeConverter {
         return try wrapped(limit: nil).hasDecode()
     }
 
+    public func usesIdentityDecode() throws -> Bool {
+        return try wrapped(limit: nil).usesIdentityDecode()
+    }
+
     public func decodeName() throws -> String {
         return generator.helperLibrary().name(.optionalDecode)
     }
@@ -57,7 +61,15 @@ public struct OptionalConverter: TypeConverter {
     }
 
     public func callDecodeField(json: any TSExpr) throws -> any TSExpr {
-        guard try hasDecode() else { return json }
+        if try usesIdentityDecode() {
+            if try hasJSONType() {
+                return TSAsExpr(
+                    TSAsExpr(json, TSIdentType("unknown")),
+                    try fieldType(for: .entity).type
+                )
+            }
+            return json
+        }
         let decodeName = generator.helperLibrary().name(.optionalFieldDecode)
         return try generator.callDecode(
             callee: TSIdentExpr(decodeName),
@@ -74,6 +86,10 @@ public struct OptionalConverter: TypeConverter {
         return try wrapped(limit: nil).hasEncode()
     }
 
+    public func usesIdentityEncode() throws -> Bool {
+        return try wrapped(limit: nil).usesIdentityEncode()
+    }
+
     public func encodeName() throws -> String {
         return generator.helperLibrary().name(.optionalEncode)
     }
@@ -86,7 +102,15 @@ public struct OptionalConverter: TypeConverter {
     }
 
     public func callEncodeField(entity: any TSExpr) throws -> any TSExpr {
-        guard try hasEncode() else { return entity }
+        if try usesIdentityEncode() {
+            if try hasJSONType() {
+                return TSAsExpr(
+                    TSAsExpr(entity, TSIdentType("unknown")),
+                    try fieldType(for: .json).type
+                )
+            }
+            return entity
+        }
         let encodeName = generator.helperLibrary().name(.optionalFieldEncode)
         return try generator.callEncode(
             callee: TSIdentExpr(encodeName),

--- a/Sources/CodableToTypeScript/TypeConverter/StructConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/StructConverter.swift
@@ -14,12 +14,6 @@ public struct StructConverter: TypeConverter {
     private var decl: StructDecl { `struct`.decl }
 
     public func typeDecl(for target: GenerationTarget) throws -> TSTypeDecl? {
-        switch target {
-        case .entity: break
-        case .json:
-            guard try hasJSONType() else { return nil }
-        }
-
         var fields: [TSObjectType.Field] = []
 
         try withErrorCollector { collect in
@@ -63,15 +57,21 @@ public struct StructConverter: TypeConverter {
     }
     
     public func hasDecode() throws -> Bool {
+        return true
+    }
+
+    public func usesIdentityDecode() throws -> Bool {
         let map = `struct`.contextSubstitutionMap()
 
-        var result = false
+        var result = true
         try withErrorCollector { collect in
             for p in decl.storedProperties.instances {
-                result = result || collect(at: "\(p.name)") {
+                let fieldUsesIdentity = collect(at: "\(p.name)") {
                     let converter = try generator.converter(for: p.interfaceType.subst(map: map))
-                    return try converter.hasDecode()
+                    let needsFallbackCast = try converter.hasJSONType() && !converter.hasDecode()
+                    return try converter.usesIdentityDecode() && !needsFallbackCast
                 } ?? false
+                result = result && fieldUsesIdentity
             }
         }
         return result
@@ -79,6 +79,13 @@ public struct StructConverter: TypeConverter {
 
     public func decodeDecl() throws -> TSFunctionDecl? {
         guard let function = try decodeSignature() else { return nil }
+
+        if try usesIdentityDecode() {
+            function.body.elements.append(
+                TSReturnStmt(TSIdentExpr.json)
+            )
+            return function
+        }
 
         var nameProvider = NameProvider()
         nameProvider.register(signature: function)
@@ -128,15 +135,21 @@ public struct StructConverter: TypeConverter {
     }
 
     public func hasEncode() throws -> Bool {
+        return true
+    }
+
+    public func usesIdentityEncode() throws -> Bool {
         let map = `struct`.contextSubstitutionMap()
 
-        var result = false
+        var result = true
         try withErrorCollector { collect in
             for p in decl.storedProperties.instances {
-                result = result || collect(at: "\(p.name)") {
+                let fieldUsesIdentity = collect(at: "\(p.name)") {
                     let converter = try generator.converter(for: p.interfaceType.subst(map: map))
-                    return try converter.hasEncode()
+                    let needsFallbackCast = try converter.hasJSONType() && !converter.hasEncode()
+                    return try converter.usesIdentityEncode() && !needsFallbackCast
                 } ?? false
+                result = result && fieldUsesIdentity
             }
         }
         return result
@@ -144,6 +157,13 @@ public struct StructConverter: TypeConverter {
 
     public func encodeDecl() throws -> TSFunctionDecl? {
         guard let function = try encodeSignature() else { return nil }
+
+        if try usesIdentityEncode() {
+            function.body.elements.append(
+                TSReturnStmt(TSIdentExpr.entity)
+            )
+            return function
+        }
 
         var nameProvider = NameProvider()
         nameProvider.register(signature: function)

--- a/Sources/CodableToTypeScript/TypeConverter/TypeAliasConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeAliasConverter.swift
@@ -16,11 +16,6 @@ public struct TypeAliasConverter: TypeConverter {
     }
 
     public func typeDecl(for target: GenerationTarget) throws -> TSTypeDecl? {
-        switch target {
-        case .entity: break
-        case .json:
-            guard try hasJSONType() else { return nil }
-        }
         return TSTypeDecl(
             modifiers: [.export],
             name: try name(for: target),
@@ -32,7 +27,13 @@ public struct TypeAliasConverter: TypeConverter {
     }
 
     public func hasDecode() throws -> Bool {
-        return try underlying().hasDecode()
+        return true
+    }
+
+    public func usesIdentityDecode() throws -> Bool {
+        let underlying = try underlying()
+        let needsFallbackCast = try underlying.hasJSONType() && !underlying.hasDecode()
+        return try underlying.usesIdentityDecode() && !needsFallbackCast
     }
 
     public func decodeDecl() throws -> TSFunctionDecl? {
@@ -47,7 +48,13 @@ public struct TypeAliasConverter: TypeConverter {
     }
 
     public func hasEncode() throws -> Bool {
-        return try underlying().hasEncode()
+        return true
+    }
+
+    public func usesIdentityEncode() throws -> Bool {
+        let underlying = try underlying()
+        let needsFallbackCast = try underlying.hasJSONType() && !underlying.hasEncode()
+        return try underlying.usesIdentityEncode() && !needsFallbackCast
     }
 
     public func encodeDecl() throws -> TSFunctionDecl? {

--- a/Sources/CodableToTypeScript/TypeConverter/TypeConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeConverter.swift
@@ -12,6 +12,7 @@ public protocol TypeConverter {
     func fieldToValue(field: any TSExpr, for target: GenerationTarget) throws -> any TSExpr
     func typeDecl(for target: GenerationTarget) throws -> TSTypeDecl?
     func hasDecode() throws -> Bool
+    func usesIdentityDecode() throws -> Bool
     func decodeName() throws -> String
     func boundDecode() throws -> any TSExpr
     func callDecode(json: any TSExpr) throws -> any TSExpr
@@ -19,6 +20,7 @@ public protocol TypeConverter {
     func decodeSignature() throws -> TSFunctionDecl?
     func decodeDecl() throws -> TSFunctionDecl?
     func hasEncode() throws -> Bool
+    func usesIdentityEncode() throws -> Bool
     func encodeName() throws -> String
     func boundEncode() throws -> any TSExpr
     func callEncode(entity: any TSExpr) throws -> any TSExpr
@@ -63,6 +65,10 @@ extension TypeConverter {
         return try `default`.decodeName()
     }
 
+    public func usesIdentityDecode() throws -> Bool {
+        return try `default`.usesIdentityDecode()
+    }
+
     public func boundDecode() throws -> any TSExpr {
         return try `default`.boundDecode()
     }
@@ -81,6 +87,10 @@ extension TypeConverter {
 
     public func encodeName() throws -> String {
         return try `default`.encodeName()
+    }
+
+    public func usesIdentityEncode() throws -> Bool {
+        return try `default`.usesIdentityEncode()
     }
 
     public func boundEncode() throws -> any TSExpr {

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeMapTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeMapTests.swift
@@ -63,11 +63,15 @@ export function S_decode(json: S$JSON): S {
         a: a
     };
 }
+""", """
+export function S_encode(entity: S): S$JSON {
+    const a = entity.a as unknown as string;
+    return {
+        a: a
+    };
+}
 """
-                       ],
-            unexpecteds: ["""
-export function S_encode
-"""]
+                       ]
         )
     }
 
@@ -158,11 +162,15 @@ export function S_encode(entity: S): S$JSON {
         a: a
     };
 }
+""", """
+export function S_decode(json: S$JSON): S {
+    const a = json.a as unknown as Date;
+    return {
+        a: a
+    };
+}
 """
-                       ],
-            unexpecteds: ["""
-export function S_decode
-"""]
+                       ]
         )
     }
 

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEncodeTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEncodeTests.swift
@@ -119,7 +119,7 @@ struct S {
             externalReference: dateTypeExternal(),
             expecteds: ["""
 export function S_encode(entity: S): S$JSON {
-    const a = entity.a as E$JSON;
+    const a = E_encode(entity.a);
     const b = Date_encode(entity.b);
     return {
         a: a,

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
@@ -324,7 +324,7 @@ export function E_decode(json: E$JSON): E {
         };
     } else if ("c" in json) {
         const j = json.c;
-        const _0 = j._0;
+        const _0 = j._0 as unknown as C;
         return {
             kind: "c",
             c: {

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateExampleTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateExampleTests.swift
@@ -75,7 +75,7 @@ export function E_decode(json: E$JSON): E {
         };
     } else if ("b" in json) {
         const j = json.b;
-        const _0 = j._0 as string[];
+        const _0 = j._0 as unknown as string[];
         return {
             kind: "b",
             b: {
@@ -110,7 +110,9 @@ import {
     E1,
     E1$JSON,
     E1_decode,
+    E1_encode,
     E2,
+    E2$JSON,
     TagRecord
 } from "..";
 """, """
@@ -121,12 +123,21 @@ export type S = {
 """, """
 export type S$JSON = {
     x: E1$JSON;
-    y: E2;
+    y: E2$JSON;
 };
 """, """
 export function S_decode(json: S$JSON): S {
     const x = E1_decode(json.x);
-    const y = json.y;
+    const y = json.y as unknown as E2;
+    return {
+        x: x,
+        y: y
+    };
+}
+""", """
+export function S_encode(entity: S): S$JSON {
+    const x = E1_encode(entity.x);
+    const y = entity.y as unknown as E2$JSON;
     return {
         x: x,
         y: y
@@ -154,6 +165,7 @@ import {
     E,
     E$JSON,
     E_decode,
+    E_encode,
     TagRecord
 } from "..";
 """, """

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
@@ -37,12 +37,19 @@ struct S<T> {
 export type S<T> = {
     a: number;
 } & TagRecord<"S", [T]>;
-"""],
-            unexpecteds: ["""
-export type S$JSON<T$JSON>
 """, """
-export function S_decode<T, T$JSON>
-"""]
+export type S$JSON<T$JSON> = {
+    a: number;
+};
+""", """
+export function S_decode<T, T$JSON>(json: S$JSON<T$JSON>, T_decode: (json: T$JSON) => T): S<T> {
+    return json;
+}
+""", """
+export function S_encode<T, T$JSON>(entity: S<T>, T_encode: (entity: T) => T$JSON): S$JSON<T$JSON> {
+    return entity;
+}
+"""],
         )
     }
 
@@ -61,14 +68,18 @@ struct S {
 export type S = {
     a: K<number>;
 } & TagRecord<"S">;
-"""
-            ],
-            unexpecteds: ["""
-export type S$JSON
 """, """
-export function S_decode
+export type S$JSON = {
+    a: K$JSON<number>;
+};
 """, """
-export function S_encode
+export function S_decode(json: S$JSON): S {
+    return json;
+}
+""", """
+export function S_encode(entity: S): S$JSON {
+    return entity;
+}
 """
             ]
         )
@@ -218,13 +229,13 @@ export type S<T> = {
 export type S$JSON<T$JSON> = {
     a: K$JSON<T$JSON>;
     b: L$JSON<T$JSON>;
-    c: X<T$JSON>;
+    c: X$JSON<T$JSON>;
 };
 """, """
 export function S_decode<T, T$JSON>(json: S$JSON<T$JSON>, T_decode: (json: T$JSON) => T): S<T> {
     const a = K_decode<T, T$JSON>(json.a, T_decode);
     const b = L_decode<T, T$JSON>(json.b, T_decode);
-    const c = json.c as X<T>;
+    const c = json.c as unknown as X<T>;
     return {
         a: a,
         b: b,
@@ -332,17 +343,17 @@ export type S = {
 } & TagRecord<"S">;
 """, """
 export type S$JSON = {
-    i: K<number>;
-    a: K<A>;
+    i: K$JSON<number>;
+    a: K$JSON<A$JSON>;
     b: K$JSON<B$JSON>;
-    c: K<C>;
+    c: K$JSON<C$JSON>;
 };
 """, """
 export function S_decode(json: S$JSON): S {
-    const i = json.i as K<number>;
-    const a = json.a as K<A>;
+    const i = json.i as unknown as K<number>;
+    const a = json.a as unknown as K<A>;
     const b = K_decode<B, B$JSON>(json.b, B_decode);
-    const c = json.c as K<C>;
+    const c = json.c as unknown as K<C>;
     return {
         i: i,
         a: a,
@@ -380,15 +391,15 @@ export type S = {
 } & TagRecord<"S">;
 """, """
 export type S$JSON = {
-    a: K<number | null>;
-    b: K<number[]>;
+    a: K$JSON<number | null>;
+    b: K$JSON<number[]>;
     c: K$JSON<E$JSON | null>;
     d: K$JSON<E$JSON[]>;
 };
 """, """
 export function S_decode(json: S$JSON): S {
-    const a = json.a as K<number | null>;
-    const b = json.b as K<number[]>;
+    const a = json.a as unknown as K<number | null>;
+    const b = json.b as unknown as K<number[]>;
     const c = K_decode<E | null, E$JSON | null>(json.c, (json: E$JSON | null): E | null => {
         return Optional_decode<E, E$JSON>(json, E_decode);
     });
@@ -549,13 +560,13 @@ export type U = {
 export type U$JSON = {
     k: S_K$JSON<E$JSON>;
     k2: S_K2$JSON<E$JSON>;
-    k3: S_K<number>;
+    k3: S_K$JSON<number>;
 };
 """, """
 export function U_decode(json: U$JSON): U {
     const k = S_K_decode<E, E$JSON>(json.k, E_decode);
     const k2 = S_K2_decode<E, E$JSON>(json.k2, E_decode);
-    const k3 = json.k3 as S_K<number>;
+    const k3 = json.k3 as unknown as S_K<number>;
     return {
         k: k,
         k2: k2,
@@ -645,7 +656,7 @@ export function K_encode<T, T$JSON>(entity: K<T>, T_encode: (entity: T) => T$JSO
         E$JSON,
         T,
         T$JSON
-    >(entity.k, identity, T_encode);
+    >(entity.k, E_encode, T_encode);
     return {
         k: k
     };

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
@@ -366,6 +366,62 @@ export function S_decode(json: S$JSON): S {
         )
     }
 
+    func testApplyGenericWithIdentityCodedTag() throws {
+        var typeMap = TypeMap.default
+        typeMap.table["Box"] = .coding(
+            entityType: "Box",
+            jsonType: "Box_JSON",
+            decode: "Box_decode",
+            encode: "Box_encode"
+        )
+
+        let typeConverterProvider = TypeConverterProvider(
+            typeMap: typeMap,
+            customProvider: { (gen, ty) in
+                guard let cnv = try TypeConverterProvider.defaultConverter(generator: gen, type: ty) else {
+                    return nil
+                }
+
+                if let cnv = cnv as? EnumConverter {
+                    return EnumConverter(generator: gen, enum: cnv.enum, emptyEnumStrategy: .void)
+                }
+
+                return nil
+            }
+        )
+
+        try assertGenerate(
+            source: """
+enum K {}
+struct Box<T> {}
+typealias ID = Box<K>
+""",
+            typeConverterProvider: typeConverterProvider,
+            externalReference: ExternalReference(
+                symbols: ["Box", "Box_JSON", "Box_decode", "Box_encode"],
+                code: """
+                export type Box<T> = string & { __tag?: T };
+                export type Box_JSON<T$JSON> = string;
+                export function Box_decode<T, T$JSON>(json: Box_JSON<T$JSON>, T_decode: (json: T$JSON) => T): Box<T> { throw 0; }
+                export function Box_encode<T, T$JSON>(entity: Box<T>, T_encode: (entity: T) => T$JSON): Box_JSON<T$JSON> { throw 0; }
+                """
+            ),
+            expecteds: ["""
+export type ID = Box<K>;
+""", """
+export type ID$JSON = Box_JSON<K$JSON>;
+""", """
+export function ID_decode(json: ID$JSON): ID {
+    return Box_decode<K, K$JSON>(json, K_decode);
+}
+""", """
+export function ID_encode(entity: ID): ID$JSON {
+    return Box_encode<K, K$JSON>(entity, K_encode);
+}
+"""]
+        )
+    }
+
     func testApplyComposedType() throws {
         try assertGenerate(
             source: """

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateImportTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateImportTests.swift
@@ -44,6 +44,7 @@ import {
     C,
     TagRecord,
     X,
+    X$JSON,
     Y
 }
 """
@@ -85,9 +86,11 @@ import {
     E,
     E$JSON,
     E_decode,
+    E_encode,
     S,
     S$JSON,
     S_decode,
+    S_encode,
     TagRecord
 }
 """]

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateNestedTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateNestedTests.swift
@@ -105,11 +105,23 @@ struct C {
 """,
             typeSelector: .name("C"),
             expecteds: ["""
-import { A_B, TagRecord } from "..";
+import { A_B, A_B$JSON, TagRecord } from "..";
 """, """
 export type C = {
     b: A_B;
 } & TagRecord<"C">;
+""", """
+export type C$JSON = {
+    b: A_B$JSON;
+};
+""", """
+export function C_decode(json: C$JSON): C {
+    return json;
+}
+""", """
+export function C_encode(entity: C): C$JSON {
+    return entity;
+}
 """]
         )
     }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
@@ -169,7 +169,7 @@ export type S$JSON = number | null;
 """, """
 export function S_decode(json: S$JSON): S {
     return {
-        rawValue: json as number | null ?? undefined
+        rawValue: json as unknown as number | null ?? undefined
     };
 }
 """, """
@@ -231,12 +231,12 @@ export type S$JSON = string[];
 """, """
 export function S_decode(json: S$JSON): S {
     return {
-        rawValue: json as string[]
+        rawValue: json as unknown as string[]
     };
 }
 """, """
 export function S_encode(entity: S): S$JSON {
-    return entity.rawValue as string[];
+    return entity.rawValue as unknown as string[];
 }
 """]
         )
@@ -259,16 +259,16 @@ export type S = {
     rawValue: K;
 } & TagRecord<"S">;
 """, """
-export type S$JSON = K;
+export type S$JSON = K$JSON;
 """, """
 export function S_decode(json: S$JSON): S {
     return {
-        rawValue: json
+        rawValue: json as unknown as K
     };
 }
 """, """
 export function S_encode(entity: S): S$JSON {
-    return entity.rawValue;
+    return entity.rawValue as unknown as K$JSON;
 }
 """]
         )
@@ -300,7 +300,7 @@ export function S_decode(json: S$JSON): S {
 }
 """, """
 export function S_encode(entity: S): S$JSON {
-    return entity.rawValue as E$JSON;
+    return E_encode(entity.rawValue);
 }
 """
                        ]
@@ -433,7 +433,7 @@ export function S_decode(json: S$JSON): S {
 }
 """, """
 export function S_encode(entity: S): S$JSON {
-    return entity.rawValue as K$JSON<E$JSON>;
+    return K_encode<E, E$JSON>(entity.rawValue, E_encode);
 }
 """
                        ]
@@ -457,16 +457,16 @@ export type S = {
     rawValue: K<number>;
 } & TagRecord<"S">;
 """, """
-export type S$JSON = K<number>;
+export type S$JSON = K$JSON<number>;
 """, """
 export function S_decode(json: S$JSON): S {
     return {
-        rawValue: json as K<number>
+        rawValue: json as unknown as K<number>
     };
 }
 """, """
 export function S_encode(entity: S): S$JSON {
-    return entity.rawValue as K<number>;
+    return entity.rawValue as unknown as K$JSON<number>;
 }
 """
                        ]

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateStructTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateStructTests.swift
@@ -15,11 +15,21 @@ export type S = {
     a: number;
     b: string;
 } & TagRecord<"S">;
+""", """
+export type S$JSON = {
+    a: number;
+    b: string;
+};
+""", """
+export function S_decode(json: S$JSON): S {
+    return json;
+}
+""", """
+export function S_encode(entity: S): S$JSON {
+    return entity;
+}
 """
-            ],
-            unexpecteds: ["""
-export function S_decode
-"""]
+            ]
         )
     }
 
@@ -126,8 +136,14 @@ struct S {
     var e3: Int???
 """,
             typeSelector: .name("S"),
-            unexpecteds: ["""
-export function S_decode
+            expecteds: ["""
+export function S_decode(json: S$JSON): S {
+    return json;
+}
+""", """
+export function S_encode(entity: S): S$JSON {
+    return entity;
+}
 """
             ]
         )
@@ -179,8 +195,14 @@ struct S {
 """
             ,
             typeSelector: .name("S"),
-            unexpecteds: ["""
-export function S_decode
+            expecteds: ["""
+export function S_decode(json: S$JSON): S {
+    return json;
+}
+""", """
+export function S_encode(entity: S): S$JSON {
+    return entity;
+}
 """]
         )
     }
@@ -252,7 +274,7 @@ export function S_decode(json: S$JSON): S {
 }
 
 export function S_encode(entity: S): S$JSON {
-    const e1 = Set_encode<E, E$JSON>(entity.e1, identity);
+    const e1 = Set_encode<E, E$JSON>(entity.e1, E_encode);
     return {
         e1: e1
     };
@@ -307,8 +329,12 @@ export function S_decode(json: S$JSON): S {
 }
 """, """
 export function S_encode(entity: S): S$JSON {
-    const e1 = Dictionary_encode<E, E$JSON>(entity.e1, identity);
-    const e2 = Dictionary_encode<(E | null)[], (E$JSON | null)[]>(entity.e2, identity);
+    const e1 = Dictionary_encode<E, E$JSON>(entity.e1, E_encode);
+    const e2 = Dictionary_encode<(E | null)[], (E$JSON | null)[]>(entity.e2, (entity: (E | null)[]): (E$JSON | null)[] => {
+        return Array_encode<E | null, E$JSON | null>(entity, (entity: E | null): E$JSON | null => {
+            return Optional_encode<E, E$JSON>(entity, E_encode);
+        });
+    });
     const e3 = Dictionary_encode<number, number>(entity.e3, identity);
     return {
         e1: e1,

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateTypeAliasTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateTypeAliasTests.swift
@@ -9,11 +9,18 @@ typealias A = Int
 """,
             expecteds: ["""
 export type A = number;
+""", """
+export type A$JSON = number;
+""", """
+export function A_decode(json: A$JSON): A {
+    return json;
+}
+""", """
+export function A_encode(entity: A): A$JSON {
+    return entity;
+}
 """
-            ],
-            unexpecteds: ["""
-export type A$JSON
-"""]
+            ]
         )
     }
 

--- a/Tests/CodableToTypeScriptTests/SubstitutionTests.swift
+++ b/Tests/CodableToTypeScriptTests/SubstitutionTests.swift
@@ -21,6 +21,8 @@ struct A {
             .converter(for: sType)
         XCTAssertEqual(try sConverter.hasDecode(), true)
         XCTAssertEqual(try sConverter.hasEncode(), true)
+        XCTAssertEqual(try sConverter.usesIdentityDecode(), false)
+        XCTAssertEqual(try sConverter.usesIdentityEncode(), false)
 
         let aDecl = try XCTUnwrap(source.find(name: "A"))
 
@@ -30,8 +32,10 @@ struct A {
             .interfaceType)
         let fooConverter = try CodeGenerator(context: context)
             .converter(for: fooType)
-        XCTAssertEqual(try fooConverter.hasDecode(), false)
-        XCTAssertEqual(try fooConverter.hasEncode(), false)
+        XCTAssertEqual(try fooConverter.hasDecode(), true)
+        XCTAssertEqual(try fooConverter.hasEncode(), true)
+        XCTAssertEqual(try fooConverter.usesIdentityDecode(), true)
+        XCTAssertEqual(try fooConverter.usesIdentityEncode(), true)
 
         let barType = try XCTUnwrap(aDecl.asStruct?
             .findInNominalTypeDecl(name: "bar", options: LookupOptions())?
@@ -41,6 +45,8 @@ struct A {
             .converter(for: barType)
         XCTAssertEqual(try barConverter.hasDecode(), true)
         XCTAssertEqual(try barConverter.hasEncode(), true)
+        XCTAssertEqual(try barConverter.usesIdentityDecode(), false)
+        XCTAssertEqual(try barConverter.usesIdentityEncode(), false)
 
         let bazType = try XCTUnwrap(aDecl.asStruct?
             .findInNominalTypeDecl(name: "baz", options: LookupOptions())?
@@ -48,10 +54,12 @@ struct A {
             .interfaceType)
         let bazConverter = try CodeGenerator(context: context)
             .converter(for: bazType)
-        XCTAssertThrowsError(try bazConverter.hasDecode()) { (error) in
+        XCTAssertEqual(try bazConverter.hasDecode(), true)
+        XCTAssertEqual(try bazConverter.hasEncode(), true)
+        XCTAssertThrowsError(try bazConverter.usesIdentityDecode()) { (error) in
             XCTAssertTrue("\(error)".contains("Error type can't be evaluated: UNKNOWN"), "rawError: \(error)")
         }
-        XCTAssertThrowsError(try bazConverter.hasEncode()) { (error) in
+        XCTAssertThrowsError(try bazConverter.usesIdentityEncode()) { (error) in
             XCTAssertTrue("\(error)".contains("Error type can't be evaluated: UNKNOWN"), "rawError: \(error)")
         }
     }


### PR DESCRIPTION
従来、エンティティ型とJSON型が同じ形の場合、encoder/decoder関数を通す必要がないため、
関数を生成しないというアプローチをとっていた。

だがこれだと、
C2TS で生成した型をさらに利用するコードを生成する場合に、
`Foo$JSON` があったりなかったりするため、
C2TS の API を正しく使う必要があり、面倒だった。

固定で `$JSON`, decoder, encoder が生成される方が、
それを利用するコードをテキスト的に固定パターンにできる場面が増えて便利。

そこで struct, enum については固定でそれらを出力するようにする。
ただし、変換が不要な場合は中身は単にreturnするだけにする。
これを `usesIdentityDecode` という性質として、クエリできるようにする。

カスタムマップについては従来より `Swift.Int` を `JS.number` にしたい場合などがあり、
こうしたケースで encode も decode もない場合の挙動は維持する。

つまり、encoder/decoderの有無を問い合わせるインターフェース設計は変更しない。
具体的な struct, enum のコード生成の挙動が変化するだけ。
